### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["chris@cmdli.dev"]
 readme = "README.md"
 license = "MIT"
 description = "A tool to manage FIDO2 devices"
-homepage = "https://github.com/cmdli/fidoprobe"
+repository = "https://github.com/cmdli/fidoprobe"
 keywords = ["fido", "fido2", "passkey"]
 categories = ["command-line-utilities"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.